### PR TITLE
Update systemd-networkd.md to reflect correct params for Ubuntu 2*.04…

### DIFF
--- a/extras/systemd-networkd.md
+++ b/extras/systemd-networkd.md
@@ -48,7 +48,7 @@ Populate the file
 [Match]
 Name=can0
 
-[Network]
+[CAN]
 BitRate=1000000
 ```
 
@@ -152,7 +152,7 @@ can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT gro
 
 To fix this add a udev rule:
 ```bash
-sudo nano /etc/udev/rules.d/99-can.link
+sudo nano /etc/udev/rules.d/99-canbus.rules
 ```
 
 Enter the contents:


### PR DESCRIPTION
Updated the /etc/systemd/network/80-can.network to use [CAN] instead of [Network]
Updated the udev file name to reflect the need for the .rules extension